### PR TITLE
Update arm_devices.xml

### DIFF
--- a/PackageFiles/DeviceData/arm_devices.xml
+++ b/PackageFiles/DeviceData/arm_devices.xml
@@ -1693,6 +1693,39 @@ NOTES:
          <registerDescriptionRef ref="CortexM4F-register-description" />
          <note>K10P144M120SF3RM</note>
       </device>
+<!-- MK11-M5 -->
+      <device name="MK11DN512M5" family="CortexM4" subfamily="MK11D5">
+         <memoryRef ref="kinetis32K_32K_Ram" />
+         <memoryRef ref="FTFL_PFlash0_SEC_512K_2KS" />
+         <memoryRef ref="kinetisIO_MK" />
+         <sdid value="0x00001226" mask="0x00000FF0"/>
+         <tclScriptRef ref="Kinetis-Kxx-Scripts" />
+         <flashProgramRef ref="Kinetis-FTFL-flash-program" />
+         <registerDescriptionRef ref="CortexM4-register-description" />
+         <note>K11P80M50SF4RM, K11P121M50SF4RM</note>
+      </device>
+      <device name="MK11DX128M5" family="CortexM4" subfamily="MK11D5">
+         <memoryRef ref="kinetis16K_16K_Ram" />
+         <memoryRef ref="FTFL_PFlash0_SEC_128K_2KS" />
+         <memoryRef ref="FTFL_DFlash0_64K_2KS" />
+         <memoryRef ref="kinetisIO_MK" />
+         <sdid value="0x00001226" mask="0x00000FF0"/>
+         <tclScriptRef ref="Kinetis-Kxx-Scripts" />
+         <flashProgramRef ref="Kinetis-FTFL-flash-program" />
+         <registerDescriptionRef ref="CortexM4-register-description" />
+         <note>K11P80M50SF4RM, K11P121M50SF4RM</note>
+      </device>
+      <device name="MK11DX256M5" family="CortexM4" subfamily="MK11D5">
+         <memoryRef ref="kinetis16K_16K_Ram" />
+         <memoryRef ref="FTFL_PFlash0_SEC_256K_2KS" />
+         <memoryRef ref="FTFL_DFlash0_64K_2KS" />
+         <memoryRef ref="kinetisIO_MK" />
+         <sdid value="0x00001226" mask="0x00000FF0"/>
+         <tclScriptRef ref="Kinetis-Kxx-Scripts" />
+         <flashProgramRef ref="Kinetis-FTFL-flash-program" />
+         <registerDescriptionRef ref="CortexM4-register-description" />
+         <note>K11P80M50SF4RM, K11P121M50SF4RM</note>
+      </device>
 <!-- MK20-M5 -->
       <device name="MK20DN32M5"  family="CortexM4" subfamily="MK20D5">
          <memoryRef ref="kinetis4K_4K_Ram" />
@@ -1884,7 +1917,7 @@ NOTES:
          <memoryRef ref="kinetis32K_32K_Ram" />
          <memoryRef ref="FTFL_PFlash0_SEC_512K_2KS" />
          <memoryRef ref="kinetisIO_MK" />
-         <sdid value="0x00002300" mask="0x00000FF0"/>
+         <sdid value="0x00009236" mask="0x00000FF0"/>
          <tclScriptRef ref="Kinetis-Kxx-Scripts" />
          <flashProgramRef ref="Kinetis-FTFL-flash-program" />
          <registerDescriptionRef ref="CortexM4-register-description" />
@@ -1895,7 +1928,7 @@ NOTES:
          <memoryRef ref="FTFL_PFlash0_SEC_128K_2KS" />
          <memoryRef ref="FTFL_DFlash0_64K_2KS" />
          <memoryRef ref="kinetisIO_MK" />
-         <sdid value="0x00002300" mask="0x00000FF0"/>
+         <sdid value="0x00009236" mask="0x00000FF0"/>
          <tclScriptRef ref="Kinetis-Kxx-Scripts" />
          <flashProgramRef ref="Kinetis-FTFL-flash-program" />
          <registerDescriptionRef ref="CortexM4-register-description" />
@@ -1906,7 +1939,7 @@ NOTES:
          <memoryRef ref="FTFL_PFlash0_SEC_256K_2KS" />
          <memoryRef ref="FTFL_DFlash0_64K_2KS" />
          <memoryRef ref="kinetisIO_MK" />
-         <sdid value="0x00002300" mask="0x00000FF0"/>
+         <sdid value="0x00009236" mask="0x00000FF0"/>
          <tclScriptRef ref="Kinetis-Kxx-Scripts" />
          <flashProgramRef ref="Kinetis-FTFL-flash-program" />
          <registerDescriptionRef ref="CortexM4-register-description" />
@@ -2787,9 +2820,9 @@ NOTES:
       <device name="K10DX256Z"         alias="MK10DX256ZM10"     hidden="true"/>
       <device name="K10FN1M0"          alias="MK10FN1M0M12"      hidden="true"/>
       <device name="K10FX512"          alias="MK10FX512M12"      hidden="true"/>
-      <!-- device name="K11DN512M5"        alias="MK11DN512M5"       hidden="true"/-->
-      <!-- device name="K11DX128M5"        alias="MK11DX128M5"       hidden="true"/-->
-      <!-- device name="K11DX256M5"        alias="MK11DX256M5"       hidden="true"/-->
+      <device name="K11DN512M5"        alias="MK11DN512M5"       hidden="true"/>
+      <device name="K11DX128M5"        alias="MK11DX128M5"       hidden="true"/>
+      <device name="K11DX256M5"        alias="MK11DX256M5"       hidden="true"/>
       <!-- device name="K12DN512M5"        alias="MK12DN512M5"       hidden="true"/-->
       <!-- device name="K12DX128M5"        alias="MK12DX128M5"       hidden="true"/-->
       <!-- device name="K12DX256M5"        alias="MK12DX256M5"       hidden="true"/-->


### PR DESCRIPTION
Added MK11 Processor, simply uncommented line 2823-2825

Added the 3 devices : MK11DN(512/128/256)M5 followinf the MK21-M5 model line 1696-1728

Correction of MK21M5 <sdid value="0x00002300" mask="0x00000FF0"/>
to <sdid value="0x00009236" mask="0x00000FF0"/>
0x00002300 value isn't working, 0x00009236 is the id of MK21D128M5, not sure if it's the same for 256 and 512 version.

The value of MK11M5 is also for the MK11D128M5, not sure if it's the same for the 256 and 512 version.

I flashed both MK21D128M5 and MK11D128M5 with those modifications.