### PR TITLE
Fixed MKL02 Device Data and added MCF5211-13 Device Data

### DIFF
--- a/PackageFiles/DeviceData/arm_kinetis_devices.xml
+++ b/PackageFiles/DeviceData/arm_kinetis_devices.xml
@@ -1309,7 +1309,7 @@ Test Devices:
          <memoryRef ref="kinetis256b_768b_Ram" />
          <memoryRef ref="FTFA_PFlash0_SEC_8K_1KS" />
          <memoryRef ref="kinetisIO_MKL" />
-         <sdid value="0x02130602" mask="0xFFFF0000"/>
+         <sdid value="0x02110602" mask="0xFFFF0000"/>
          <tclScriptRef ref="Kinetis-MKLxx-Scripts" />
          <flashProgramRef ref="Kinetis-FTFA-MKL-flash-program" />
          <registerDescriptionRef ref="CortexM0-register-description" />
@@ -1318,7 +1318,7 @@ Test Devices:
          <memoryRef ref="kinetis512b_1536b_Ram" />
          <memoryRef ref="FTFA_PFlash0_SEC_16K_1KS" />
          <memoryRef ref="kinetisIO_MKL" />
-         <sdid value="0x02130602" mask="0xFFFF0000"/>
+         <sdid value="0x02120602" mask="0xFFFF0000"/>
          <tclScriptRef ref="Kinetis-MKLxx-Scripts" />
          <flashProgramRef ref="Kinetis-FTFA-MKL-flash-program" />
          <registerDescriptionRef ref="CortexM0-register-description" />

--- a/PackageFiles/DeviceData/cfvx_devices.xml
+++ b/PackageFiles/DeviceData/cfvx_devices.xml
@@ -128,6 +128,27 @@
          <registerDescriptionRef ref="Coldfire-register-description" />
          <note>Default CFV1 Device</note>
       </device>
+     <!--
+         =======================================================================
+      -->
+     <device family="CFVx" name="MCF5211" subfamily="MCF521x">
+         <clock type="External" registerAddress="0" />
+         <memoryRef ref="coldfire16K_Ram" />
+         <memoryRef ref="coldfire128K_Flash" />
+         <sdid value="0x0F40" />
+      </device>      
+      <device family="CFVx" name="MCF5212" subfamily="MCF521x">
+         <clock type="External" registerAddress="0" />
+         <memoryRef ref="coldfire32K_Ram" />
+         <memoryRef ref="coldfire256K_Flash" />
+         <sdid value="0x1080" />
+      </device>
+      <device family="CFVx" name="MCF5213" subfamily="MCF521x">
+         <clock type="External" registerAddress="0" />
+         <memoryRef ref="coldfire32K_Ram" />
+         <memoryRef ref="coldfire256K_Flash" />
+         <sdid value="0x10C0" />
+      </device>
       <!--
          =======================================================================
       -->


### PR DESCRIPTION
Hi Peter,
I recently began to work with KL02 devices where I realized that the SDID in the Device_Data for the MKL02Z8M4 and MKL02Z16M4 are wrong, so I fixed them.
I further added the Device Data for MCF521x Devices.
Unfortunately I could just check the data for the MKL02Z16M4 and the MCF5212, but I think the other Devices are save to use, as the changes are pretty small.

Greetings from Switzerland,
Roman