### PR TITLE
[JS16_Bootloader] Significantly increase flashing speed

### DIFF
--- a/JS16_Bootloader/src/ICP.cpp
+++ b/JS16_Bootloader/src/ICP.cpp
@@ -133,6 +133,11 @@ USBDM_ErrorCode ICP_Program(unsigned int         addr,
             log.print("Failed bdm_usb_raw_send_ep0()\n");
             return rc;
          }
+	 // Wait 2ms before we try to get the result to ensure that the
+	 // operation won't still be in progress the first time getResult()
+	 // polls the device. This avoids an extra 100ms retry timeout that
+	 // getResult() would otherwise add.
+         UsbdmSystem::milliSleep(2);
          rc = getResult();
          if (rc != BDM_RC_OK) {
             log.print("Failed icp_get_result() rc = %d\n", rc);


### PR DESCRIPTION
By experimentation on a USBDM_JS16_JS16CWJ V1.1, one program operation of 32 bytes (which is the record size of the supplied prebuilt image) takes between 1ms and 2ms. Currently, we call `getResult()` immediately after sending each program command. Since we don't wait at all, this often fails the first time and ends up waiting 100ms before checking again. By adding an explicit delay of 2ms before checking the result code, we guarantee that the result will be ready the first time we check it.

This change reduces programming time on my device from over 20 seconds to around three seconds.