### PR TITLE
FirmwareChanger and JS16_Bootloader execution from command line

### DIFF
--- a/FirmwareChanger/src/FirmwareChanger.h
+++ b/FirmwareChanger/src/FirmwareChanger.h
@@ -65,6 +65,10 @@ typedef struct {
 class FirmwareChangerDialogue : public FirmwareChangerSkeleton {
 
 protected:
+	enum DialogueMode{
+	    	       GUI_MODE,
+	    		   CMD_LINE_MODE
+	    	    };
     FlashImageData            flashImageDescription;
     wxString                  errMessage;
     ICP_dataType              ICP_data;
@@ -78,6 +82,12 @@ protected:
     bool                      autoSequenceFlag;
     int                       autoSequenceNumber;
     bool                      autoUpdateBdm;
+    bool                      verify;
+    bool                      program;
+    bool                      verbose;
+    bool                      enableAutoLoad;
+    bool                      enableConsole;
+    DialogueMode              activeMode;
 
     bool   loadFlashImageFile(wxString path);
     void   setSerialNumber(const wxString &serialNumber);
@@ -106,6 +116,7 @@ protected:
     void   textControlToSerialNumber(void);
     void   parseSerialNumber(const wxString &serialNumber, wxString &serialNumberPrefix);
     void   updateControls(void);
+    virtual void logUsageError(wxCmdLineParser& parser, const wxString& text);
 
 public:
     enum {
@@ -168,6 +179,15 @@ public:
     void   loadSettings(const AppSettings &settings);
     void   saveSettings(AppSettings &settings);
     void   setAutoLoad(bool value);
+
+    // command line functions
+    virtual int doCommandLineProgram();
+    virtual int parseCommandLine(wxCmdLineParser& parser);
+
+    virtual std::string getConsoleMessage();
+    bool inGUIMode(){return activeMode == GUI_MODE;}
+    bool doAutoLoad(){return enableAutoLoad;}
+    bool consoleIsEnabled(){return enableConsole;}
 };
 
 #endif

--- a/JS16_Bootloader/src/JS16_Bootloader.cpp
+++ b/JS16_Bootloader/src/JS16_Bootloader.cpp
@@ -16,7 +16,6 @@
 #include "ICP.h"
 #include "Names.h"
 #include "FlashImageFactory.h"
-#include "ProgressDialogueFactory.h"
 #include "JS16_Bootloader.h"
 
 USBDM_ErrorCode programBlock(FlashImagePtr flashImage, uint32_t size, uint32_t startBlock, ProgressDialoguePtr callBack) {
@@ -72,7 +71,7 @@ USBDM_ErrorCode programFlashImage(FlashImagePtr flashImage, ProgressDialoguePtr 
    return progRc;
 }
 
-USBDM_ErrorCode ProgramDevice(std::string filePath) {
+USBDM_ErrorCode ProgramDevice(std::string filePath, ProgressDialoguePtr progressCallback) {
    LOGGING_Q;
    USBDM_ErrorCode rc;
 
@@ -89,8 +88,7 @@ USBDM_ErrorCode ProgramDevice(std::string filePath) {
                           flashImage->getFirstAllocatedAddress(), 0xFF);
 
    do {
-      ProgressDialoguePtr progressCallback = ProgressDialogueFactory::create("Accessing Target", flashImage->getByteCount());
-
+	  progressCallback->setRange(flashImage->getByteCount());
       progressCallback->update(0, "Initialising...");
       log.print("Initialising\n");
       rc = ICP_Init();

--- a/JS16_Bootloader/src/JS16_Bootloader.h
+++ b/JS16_Bootloader/src/JS16_Bootloader.h
@@ -11,7 +11,8 @@
 
 #include "USBDM_API.h"
 #include "ICP.h"
+#include "ProgressDialogueFactory.h"
 
-USBDM_ErrorCode ProgramDevice(std::string hexFileName);
+USBDM_ErrorCode ProgramDevice(std::string hexFileName, ProgressDialoguePtr progressCallback);
 
 #endif /* JS16_BOOTLOADER_H_ */

--- a/JS16_Bootloader/src/JS16_BootloaderApp.cpp
+++ b/JS16_Bootloader/src/JS16_BootloaderApp.cpp
@@ -34,6 +34,7 @@ Change History
 #include <wx/cmdline.h>
 #include <wx/stdpaths.h>
 
+
 #include "Common.h"
 #include "MainDialogue.h"
 #include "UsbdmSystem.h"
@@ -55,9 +56,14 @@ class JS16_BootloaderApp : public wxApp {
    DECLARE_EVENT_TABLE()
 
 private:
-   OpenLog        openLog;
-   MainDialogue  *dialogue;
-   int            returnValue;
+   OpenLog           openLog;
+   MainDialogue      *dialogue;
+   AppSettingsPtr    appSettings;
+   USBDM_ErrorCode   applicationRC;
+   bool              consoleIsAttached;
+
+   void attachConsole();
+   void freeConsole();
 
 public:
    JS16_BootloaderApp();
@@ -66,6 +72,8 @@ public:
    virtual bool OnInit();
    virtual int  OnExit();
    virtual int  OnRun();
+   virtual void OnInitCmdLine(wxCmdLineParser& parser);
+   virtual bool OnCmdLineParsed(wxCmdLineParser& parser);
    virtual ~JS16_BootloaderApp();
 };
 
@@ -83,15 +91,21 @@ END_EVENT_TABLE()
 JS16_BootloaderApp::JS16_BootloaderApp() :
  openLog(),
  dialogue(0),
- returnValue(0) {
+ applicationRC(BDM_RC_OK),
+ consoleIsAttached(false){
    LOGGING_E;
 }
 
-// Initialise the application
+/*
+ * Initialisation for JS16_BootloaderApp
+ */
 bool JS16_BootloaderApp::OnInit(void) {
    LOGGING;
 
-   returnValue = 0;
+   applicationRC = BDM_RC_OK;
+
+   // create new main dialogue. Will first be used to parse the command line
+   dialogue = new MainDialogue(NULL);
 
    SetAppName(_("usbdm")); // So app files are kept in the correct directory
 
@@ -102,40 +116,153 @@ bool JS16_BootloaderApp::OnInit(void) {
 
    // call for default command parsing behaviour
    if (!wxApp::OnInit()) {
-      return false;
+	  applicationRC = BDM_RC_ILLEGAL_COMMAND;
    }
-
-   AppSettings settings("JS16_Bootloader.cfg", "JS16 Bootloader");
-   settings.load();
-
-   // Create the main application window
-   dialogue = new MainDialogue(NULL);
-   SetTopWindow(dialogue);
-   dialogue->ShowModal();
-   dialogue->saveSettings(settings);
+   else if(applicationRC == BDM_RC_OK){
+	   // Prepare the GUI application
+	  if(dialogue->inGUIMode()){
+	     appSettings.reset(new AppSettings("JS16_Bootloader.cfg", "JS16 Bootloader"));
+	     appSettings->load();
+	     dialogue->loadSettings(*appSettings);
+	     SetTopWindow(dialogue);
+	     dialogue->ShowModal();
+	     dialogue->saveSettings(*appSettings);
+	     appSettings->save();
+	  }
+	  else{
+		 attachConsole();
+	     applicationRC = dialogue->doCommandLineProgram();
+	     if(dialogue->consoleIsEnabled()){
+	    	 if(applicationRC != BDM_RC_OK){
+	    		 fprintf(stderr, "Programming failed, rc = %s\n", UsbdmSystem::getErrorString(applicationRC));
+	    	 }
+	    	 else{
+	    		 fprintf(stdout, "Programming completed successfully\n");
+	    	 }
+	     }
+		 freeConsole();
+	  }
+   }
    dialogue->Destroy();
-
-   settings.save();
-
-   return true;
+   return true; // Return true regardless as we want OnRun() to execute
 }
 
+/*
+ * Run function for JS16_BootloaderApp
+ */
 int JS16_BootloaderApp::OnRun(void) {
    LOGGING_E;
-   int exitcode = wxApp::OnRun();
-   if (exitcode != 0)
-      return exitcode;
-   // Everything is done in OnInit()!
-   log.print("FlashProgrammerApp::OnRun() - return value = %d\n", returnValue);
-   return returnValue;
+
+   // Everything is done in OnInit()
+   if (applicationRC != BDM_RC_OK){
+	  log.error("JS16 Bootloader app::OnRun() - error code = %s\n", UsbdmSystem::getErrorString(applicationRC));
+   }
+   else{
+	  log.print("JS16 Bootloader app::OnRun() success\n");
+   }
+
+   return applicationRC;
 }
 
+/*
+ * Cleanup for JS16_BootloaderApp
+ */
 int JS16_BootloaderApp::OnExit(void) {
    LOGGING_E;
+
    return wxApp::OnExit();
 }
 
+static const std::string firmwareSelectionUsage = std::string("Valid firmware choices:\n")          +
+															  "\t0 = " + firmwareSelection[0] +"\n" +
+		                                                      "\t1 = " + firmwareSelection[1] +"\n" +
+		                                                      "\t2 = " + firmwareSelection[2] +"\n" +
+		                                                      "\t3 = " + firmwareSelection[3] +"\n" +
+		                                                      "\t4 = " + firmwareSelection[4] +"\n" +
+		                                                      "\t5 = " + firmwareSelection[5] +"\n" +
+		                                                      "\t6 = " + firmwareSelection[6] +"\n" ;
+
+static const wxCmdLineEntryDesc g_cmdLineDesc[] = {
+	  { wxCMD_LINE_PARAM,       NULL,           NULL, _("Custom BDM firmware. Must be specified if firmware option is 0"),   wxCMD_LINE_VAL_STRING, wxCMD_LINE_PARAM_OPTIONAL },
+	  { wxCMD_LINE_OPTION,      _("firmware"),  NULL, _("BDM firmware choice"),                                              wxCMD_LINE_VAL_NUMBER },
+	  { wxCMD_LINE_USAGE_TEXT,  NULL,           NULL, _(firmwareSelectionUsage)                    },
+      { wxCMD_LINE_SWITCH,      _("verbose"),   NULL, _("Print progress messages to stdout")       },
+#ifdef _WIN32
+	  { wxCMD_LINE_SWITCH,      _("console"),   NULL, _("Enable output to stdout and stderr")                 },
+#endif
+	  { wxCMD_LINE_SWITCH,      _("help"),      NULL, _("Show this help message"),                                           wxCMD_LINE_VAL_NONE,     wxCMD_LINE_OPTION_HELP  },
+	  { wxCMD_LINE_USAGE_TEXT,  NULL,           NULL, _("\nReturn codes: Check USBDM Error Codes") },
+      { wxCMD_LINE_NONE }
+};
+
+void JS16_BootloaderApp::OnInitCmdLine(wxCmdLineParser& parser){
+
+	parser.SetDesc (g_cmdLineDesc);
+	 // must refuse '/' as parameter starter or cannot use "/path" style paths
+	parser.SetSwitchChars (_("-"));
+	parser.SetLogo(_("JS16 Bootloader\n"));
+
+	#if (wxCHECK_VERSION(2, 9, 0))
+	    parser.AddUsageText(_(
+	          "\nExamples:\n"
+	          "-firmware=1\n"
+	          "    Program BDM using firmware choice 1 - " + firmwareSelection[1] + "\n"
+	    	  "-firmware=0 Image.sx\n"
+	    	  "    Program BDM using custom image file  "
+	     ));
+    #ifdef _WIN32
+	    parser.AddUsageText(_("\nRecommendation! When running on console, use \"start/wait\" to execute the application."
+    		              " For example:\n\tstart/wait JS16_Bootloader -program -firmware=1"));
+    #endif // _WIN32
+	#endif
+}
+
+bool JS16_BootloaderApp::OnCmdLineParsed(wxCmdLineParser& parser){
+
+	applicationRC = dialogue->parseCommandLine(parser);
+    if (applicationRC != BDM_RC_OK) {
+	   parser.Usage();
+    }
+	return true; // return true regardless to catch unknown/illegal command line option in OnInit()
+}
 JS16_BootloaderApp::~JS16_BootloaderApp() {
    LOGGING_E;
 }
 
+void JS16_BootloaderApp::attachConsole(){
+	LOGGING;
+
+	if(consoleIsAttached){
+		return;
+	}
+#ifdef _WIN32
+	if ((GetConsoleWindow() == NULL) && dialogue->consoleIsEnabled()) {
+		if(AttachConsole(ATTACH_PARENT_PROCESS)){ // attach to parent console if possible
+			consoleIsAttached = true;
+			log.print("Parent console attached\n");
+		}
+		else{
+			log.print("Unable to attach parent console to application. Error: %lu\n", GetLastError());
+		}
+		if(consoleIsAttached){
+			freopen("CONOUT$", "w", stdout);
+			freopen("CONOUT$", "w", stderr);
+		}
+		// Set stdout to no buffering; stderr is unbuffered by default
+		setvbuf(stdout, NULL, _IONBF, 0);
+	}
+#endif
+}
+
+void JS16_BootloaderApp::freeConsole(){
+	LOGGING;
+
+	if(!consoleIsAttached){
+		return;
+	}
+#ifdef _WIN32
+	FreeConsole();
+	consoleIsAttached = false;
+	log.print("Console detached");
+#endif
+}

--- a/JS16_Bootloader/src/MainDialogue.h
+++ b/JS16_Bootloader/src/MainDialogue.h
@@ -30,28 +30,45 @@
 ///////////////////////////////////////////////////////////////////////////////
 /// Class MainDialogue
 ///////////////////////////////////////////////////////////////////////////////
+
+extern const std::string firmwareSelection[];
+
 class MainDialogue : public BootloaderDialogueSkeleton
 {
    private:
 
    protected:
+	enum DialogueMode{
+	            	GUI_MODE,
+	            	CMD_LINE_MODE
+	};
       wxString             customFilename;
       wxString             customPath;
       wxString             defaultDirectory;
+      std::string          filePath;
+
+      bool                 verbose;
+      bool                 enableConsole;
+      DialogueMode         activeMode;
+
 
       virtual void OnProgramButtonClick( wxCommandEvent& event );
       virtual void OnLoadSourceButtonClick( wxCommandEvent& event );
       virtual void OnRadioBox( wxCommandEvent& event );
 
       void setDescription(std::string description);
+      void logUsageError(wxCmdLineParser& parser, const wxString& text);
 
    public:
 
       MainDialogue( wxWindow* parent);
       virtual ~MainDialogue();
-
       void loadSettings(const AppSettings &settings);
       void saveSettings(AppSettings &settings);
+      USBDM_ErrorCode doCommandLineProgram();
+      USBDM_ErrorCode parseCommandLine(wxCmdLineParser& parser);
+      bool inGUIMode(){return activeMode == GUI_MODE;}
+      bool consoleIsEnabled(){return enableConsole;}
 };
 
 #endif //__NONAME_H__

--- a/Shared_V4/src/ProgressDialogue.cpp
+++ b/Shared_V4/src/ProgressDialogue.cpp
@@ -66,6 +66,123 @@ public:
    }
 };
 
+class ConsoleProgressDialogue : public ProgressDialogue {
+private:
+   uint32_t          maximum;
+   uint32_t          cumulative;
+   int               currentPercent;
+   int               previousPercent;
+   std::string       updateMessage;
+   bool              verbose;
+   bool              outputEnabled;
+
+   void calculatePercent(int value) {
+      cumulative = value;
+      double percentage = (100.0*value)/maximum;
+      currentPercent = (int)round(percentage);
+      if (currentPercent >= 100) {
+         currentPercent = 99;
+      }
+   }
+
+   bool update(std::string message, bool newUpdateEntry){
+	   if(newUpdateEntry){
+		   if(previousPercent != -1 && !updateMessage.empty()){
+			   fprintf(stdout, "%s complete\n", updateMessage.c_str()); //last update is completed
+		   }
+	       previousPercent = -1;
+	       updateMessage = message;
+	       if(!updateMessage.empty()){
+	    	   fprintf(stdout, "%s\n", updateMessage.c_str());
+	       }
+	   }
+	   else{
+		   if(!message.empty()){
+			   updateMessage = message;
+		   }
+
+		   if(previousPercent != currentPercent && !updateMessage.empty()){
+			   fprintf(stdout, "%d%%: %s\n", currentPercent, updateMessage.c_str());
+		   }
+	   }
+	   previousPercent = currentPercent;
+	   return true;
+   }
+
+public:
+   ConsoleProgressDialogue(uint32_t maximum, bool verbose, bool enableOutput):
+	   maximum(maximum), cumulative(0),
+	   currentPercent(0), previousPercent(-1),
+	   verbose(verbose), outputEnabled(enableOutput)
+    {
+//      LOGGING;
+    }
+   ~ConsoleProgressDialogue() {}
+
+   bool pulse(std::string message=""){
+	   if(outputEnabled && !message.empty()){
+		   fprintf(stdout, "%s\n", message.c_str());
+	   }
+	   return true;
+   }
+
+   bool update(int amount, std::string message=""){
+	   if(!outputEnabled){
+	   	  return true;
+	   }
+	   if(!verbose){
+	      if(!message.empty()){ // print any non-empty message and return
+	         fprintf(stdout, "%s\n", message.c_str());
+	      }
+	      return true;
+	   }
+	   calculatePercent(amount);
+	   return update(message, true);
+   }
+
+   bool incrementalUpdate(int relativeAmount, std::string message=""){
+	   if(!verbose || !outputEnabled){
+		   return true;
+	   }
+	   calculatePercent(cumulative + relativeAmount);
+	   return update(message, false);
+   }
+
+   bool percentageUpdate(int percent, std::string message=""){
+	   if(!outputEnabled){
+		   return true;
+	   }
+	   if(!verbose){
+		   if(percent == 0 && !message.empty()){
+			   fprintf(stdout, "%s\n", message.c_str());
+		   }
+		   return true;
+	   }
+	   this->currentPercent = percent;
+	   updateMessage = message.empty() ? updateMessage : message;
+	   if(previousPercent != currentPercent){
+		  fprintf(stdout, "%d%%: %s\n", currentPercent, updateMessage.c_str());
+	   }
+	   previousPercent = currentPercent;
+	   return true;
+   }
+
+   void setRange(int maximum){this->maximum = maximum;}
+
+   void close(){
+	   if(!verbose || !outputEnabled){
+		   return;
+	   }
+	   if(!updateMessage.empty()){
+		   fprintf(stdout, "%s complete\n", updateMessage.c_str());
+	   }
+   }
+};
+
 ProgressDialoguePtr ProgressDialogueFactory::create(std::string title, uint32_t maximum, void *owner) {
    return ProgressDialoguePtr(new ProgressCallbackImp(title, maximum, (wxWindow*)owner));
+}
+
+ProgressDialoguePtr ProgressDialogueFactory::create(uint32_t maximum, bool verbose, bool enableOutput){
+	return ProgressDialoguePtr(new ConsoleProgressDialogue(maximum, verbose, enableOutput));
 }

--- a/Shared_V4/src/ProgressDialogueFactory.h
+++ b/Shared_V4/src/ProgressDialogueFactory.h
@@ -63,6 +63,7 @@ typedef std::shared_ptr<ProgressDialogue> ProgressDialoguePtr;
 class ProgressDialogueFactory {
 public:
    static ProgressDialoguePtr create(std::string title, uint32_t maximum, void *owner=0);
+   static ProgressDialoguePtr create(uint32_t maximum, bool verbose, bool enableOutput = true);
 };
 
 #endif /* SRC_PROGRESSCALLBACKFACTORY_H_ */


### PR DESCRIPTION
 A console mode execution is often desired in order to automate tasks, for example on a test system.
The UsbdmFlashProgrammer application can operate in hybrid mode (i.e as both a console app as well as GUI) . However, the basic functions of JS16_Bootloader and FirmwareChanger applications could only be executed from the GUI. This change enables hybrid mode for both applications.