### PR TITLE
Fix a number of Linux build failures introduced by V4.12.1.270

### DIFF
--- a/Common.mk
+++ b/Common.mk
@@ -266,7 +266,7 @@ ifeq ($(UNAME_S),Windows)
       USBDM_DSC_LIBS := -lusbdm-dsc$(VSUFFIX) 
    endif
 else
-   LIB_USB = -l$(_LIB_USB_SHARED)
+   LIB_USB = $(LIB_USB_SHARED)
    ifdef DEBUG
       USBDM_LIBS     := -lusbdm-debug
       USBDM_DSC_LIBS := -lusbdm-dsc-debug 

--- a/Common.mk
+++ b/Common.mk
@@ -11,10 +11,6 @@ PKG_NAME = usbdm
 # Used as prefix with the above when in build directory $(DUMMY_CHILD)/$(SHARED_SRC) = PackageFiles/src
 DUMMY_CHILD    := PackageFiles
 
-ifeq ('$(OS)','')
-   OS=Windows_NT
-endif
-
 #BITNESS ?= 64
 
 ifeq ($(OS),Windows_NT)

--- a/UsbdmJni_DLL/Target.mk
+++ b/UsbdmJni_DLL/Target.mk
@@ -32,9 +32,9 @@ CC = $(GPP)
 CFLAGS += -fno-exceptions
 
 LDFLAGS += $(LFLAGS)
-LDFLAGS += -Wl,--kill-at -shared 
+LDFLAGS += -shared
 ifeq ($(UNAME_S),Windows)
-LDFLAGS += 
+LDFLAGS += -Wl,--kill-at
 else	
 LDFLAGS += -Wl,-soname,$(basename $(notdir $@))
 endif


### PR DESCRIPTION
This commit seems not to have been tested on Linux at all. It introduced at least three build failures, all of which are fixed by this PR. This seems to be enough to get a `make -f Makefile-x64.mk all` working, but there could be other things broken outside of that.