### PR TITLE
udev rules: tag matching devices with uaccess instead of setting mode 0666

### DIFF
--- a/PackageFiles/MiscellaneousLinux/usbdm.rules
+++ b/PackageFiles/MiscellaneousLinux/usbdm.rules
@@ -2,14 +2,14 @@
 #  Note: HEX numbers must be lower case - yes really!!!!
 #
 # Allow unrestricted access to various BDMs (including USBDM & JS16 bootloader)
-SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="1000", SYMLINK+="usbdm-tbdml%n",     MODE:="0666"
-SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="1001", SYMLINK+="usbdm-tblcf%n",     MODE:="0666"
-SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="ff02", SYMLINK+="JB16_Bootloader%n", MODE:="0666"
-SUBSYSTEM=="usb", ATTR{idVendor}=="15a2", ATTR{idProduct}=="0021", SYMLINK+="usbdm-osbdm%n",     MODE:="0666"
-SUBSYSTEM=="usb", ATTR{idVendor}=="15a2", ATTR{idProduct}=="0038", SYMLINK+="JS16_Bootloader%n", MODE:="0666"
-SUBSYSTEM=="usb", ATTR{idVendor}=="16d0", ATTR{idProduct}=="0567", SYMLINK+="usbdm%n",           MODE:="0666"
-SUBSYSTEM=="usb", ATTR{idVendor}=="16d0", ATTR{idProduct}=="06a5", SYMLINK+="usbdm%n",           MODE:="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="1000", SYMLINK+="usbdm-tbdml%n",     TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="1001", SYMLINK+="usbdm-tblcf%n",     TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="ff02", SYMLINK+="JB16_Bootloader%n", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="15a2", ATTR{idProduct}=="0021", SYMLINK+="usbdm-osbdm%n",     TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="15a2", ATTR{idProduct}=="0038", SYMLINK+="JS16_Bootloader%n", TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="16d0", ATTR{idProduct}=="0567", SYMLINK+="usbdm%n",           TAG+="uaccess"
+SUBSYSTEM=="usb", ATTR{idVendor}=="16d0", ATTR{idProduct}=="06a5", SYMLINK+="usbdm%n",           TAG+="uaccess"
 #
 # Allow unrestricted access to USBDM CDC serial port (named ttyUsbdm0 ...)
-SUBSYSTEM=="tty", ATTRS{idVendor}=="16d0", MODE="0666", SYMLINK+="ttyUsbdm%n"
+SUBSYSTEM=="tty", ATTRS{idVendor}=="16d0", TAG+="uaccess", SYMLINK+="ttyUsbdm%n"
 #

--- a/PackageFiles/MiscellaneousLinux/usbdm.rules
+++ b/PackageFiles/MiscellaneousLinux/usbdm.rules
@@ -2,13 +2,13 @@
 #  Note: HEX numbers must be lower case - yes really!!!!
 #
 # Allow unrestricted access to various BDMs (including USBDM & JS16 bootloader)
-ATTR{idVendor}=="0425", ATTR{idProduct}=="1000", SYMLINK+="usbdm-tbdml%n",     MODE:="0666"
-ATTR{idVendor}=="0425", ATTR{idProduct}=="1001", SYMLINK+="usbdm-tblcf%n",     MODE:="0666"
-ATTR{idVendor}=="0425", ATTR{idProduct}=="ff02", SYMLINK+="JB16_Bootloader%n", MODE:="0666"
-ATTR{idVendor}=="15a2", ATTR{idProduct}=="0021", SYMLINK+="usbdm-osbdm%n",     MODE:="0666"
-ATTR{idVendor}=="15a2", ATTR{idProduct}=="0038", SYMLINK+="JS16_Bootloader%n", MODE:="0666"
-ATTR{idVendor}=="16d0", ATTR{idProduct}=="0567", SYMLINK+="usbdm%n",           MODE:="0666"
-ATTR{idVendor}=="16d0", ATTR{idProduct}=="06a5", SYMLINK+="usbdm%n",           MODE:="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="1000", SYMLINK+="usbdm-tbdml%n",     MODE:="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="1001", SYMLINK+="usbdm-tblcf%n",     MODE:="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="0425", ATTR{idProduct}=="ff02", SYMLINK+="JB16_Bootloader%n", MODE:="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="15a2", ATTR{idProduct}=="0021", SYMLINK+="usbdm-osbdm%n",     MODE:="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="15a2", ATTR{idProduct}=="0038", SYMLINK+="JS16_Bootloader%n", MODE:="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="16d0", ATTR{idProduct}=="0567", SYMLINK+="usbdm%n",           MODE:="0666"
+SUBSYSTEM=="usb", ATTR{idVendor}=="16d0", ATTR{idProduct}=="06a5", SYMLINK+="usbdm%n",           MODE:="0666"
 #
 # Allow unrestricted access to USBDM CDC serial port (named ttyUsbdm0 ...)
 SUBSYSTEM=="tty", ATTRS{idVendor}=="16d0", MODE="0666", SYMLINK+="ttyUsbdm%n"


### PR DESCRIPTION
This is a more modern and secure way to allow unprivileged access to devices. Instead of making the device readable and writable to every process on the system, we add the `uaccess` tag to tell udev that active users should automatically be added to the device's ACL. Any user that has a console or graphical session on the current virtual terminal, or who has an ongoing SSH session, is marked as active. This preserves the same ease of access as making the devices world-writable, while preventing service accounts and users who have left processes running after logging out from accessing the devices.

uaccess is the recommended way to grant users access to devices these days, and you can grep `/usr/lib/udev/rules.d/` to see that lots of similar rules are already using it. [This article](https://enotty.pipebreaker.pl/2012/05/23/linux-automatic-user-acl-management/) provides a more in-depth description of exactly how it works.

Tested on Arch Linux, but to my knowledge this should work on every major distribution that's been released in the past 5 years or so.